### PR TITLE
feat: 添加全局模块(#2)

### DIFF
--- a/zjb/gui/_global.py
+++ b/zjb/gui/_global.py
@@ -1,0 +1,54 @@
+from PyQt5.QtCore import QObject, pyqtSignal
+
+from zjb.doj.lmdb_job_manager import LMDBJobManager
+from zjb.main.manager.workspace import Workspace
+
+
+class _GlobalSignal(QObject):
+    # 全局工作空间发生变化
+    workspaceChanged = pyqtSignal([], [int])
+
+
+GLOBAL_SIGNAL = _GlobalSignal()
+
+
+"""
+Workspace相关
+"""
+
+_workspace = None
+
+
+def get_workspace() -> "Workspace | None":
+    """获取全局工作空间
+
+    Returns
+    -------
+    Workspace | None
+        全局工作空间或None(未打开任何工作空间)
+    """
+    global _workspace
+    return _workspace
+
+
+def open_workspace(path: str):
+    """打开一个工作空间作为全局工作空间
+
+    Parameters
+    ----------
+    path : str
+        要打开的工作空间的路径
+    """
+    global _workspace
+
+    jm = LMDBJobManager(path=path)
+    _workspace = Workspace.from_manager(jm)
+    GLOBAL_SIGNAL.workspaceChanged[Workspace].emit(_workspace)
+
+
+def close_workspace():
+    """关闭全局工作空间"""
+    global _workspace
+
+    GLOBAL_SIGNAL.workspaceChanged.emit()
+    _workspace = None

--- a/zjb/gui/common/global_signal.py
+++ b/zjb/gui/common/global_signal.py
@@ -1,8 +1,0 @@
-from PyQt5.QtCore import QObject, pyqtSignal
-
-
-class GlobalSignal(QObject):
-    jobUpdated = pyqtSignal()
-
-
-GSIGNAL = GlobalSignal()


### PR DESCRIPTION
使用全局模块的方案处理#2

其中包括一个全局信号类`_GlobalSignal`用于添加需要全局共享的Qt信号, 一个模块实例`GLOBAL_SIGNAL`用于触发或监听全局信号. 如需要监听提交中的工作空间变化信号:

```python
from zjb.gui._global import GLOBAL_SIGNAL
def fun(ws=None):
    if ws:
        print(f"{ws} opened")
    else:
        print("workspace closed")
GLOBAL_SIGNAL.workspaceChanged.connect(fun) # 监听工作空间关闭的信号
GLOBAL_SIGNAL.workspaceChanged[Workspace].connect(fun) # 监听工作空间变化的信号
```

同时删除了位于`zjb.gui.common`的全局信号模块